### PR TITLE
[GST-2307] Made artifact restore optional in aws_s3_restore.sh.j2 script

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ gocd_server:
   java_home: /usr/lib/jvm/java-7-oracle/jre
   port_ssl: 8154
   port: 8153
+  restore_artifacts_on_boot: true
   server_max_mem: 512m
   server_max_perm_gen: 128m
   server_mem: 256m

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -70,6 +70,8 @@
       dest: "/home/{{ gocd_server.user }}/bin/aws_s3_backup.sh"
     - src: aws_s3_restore.sh.j2
       dest: "/home/{{ gocd_server.user }}/bin/aws_s3_restore.sh"
+    - src: aws_s3_restore_artifacts.sh.j2
+      dest: "/home/{{ gocd_server.user }}/bin/aws_s3_restore_artifacts.sh"
   when: gocd_server.aws.backup_bucket
   notify:
     - restart go-server

--- a/templates/aws_s3_restore.sh.j2
+++ b/templates/aws_s3_restore.sh.j2
@@ -87,6 +87,8 @@ function main {
 	rm -rf "${TMP_RESTORE}"
 	rm -f /tmp/latest.tar.gz
 
+
+{% if gocd_server.restore_artifacts_on_boot %}
 	info "Synchronising artifacts"
 	mkdir -p "${ARTIFACTS_DIR}"
 	aws s3 sync \
@@ -94,6 +96,7 @@ function main {
 		"${ARTIFACTS_DIR}" \
 		 || die "Failed to synchronise artifacts"
 	ok "Pipelines artifacts synchronised"
+{% endif %}
 
 	info "Starting Go Server"
 	service go-server start

--- a/templates/aws_s3_restore_artifacts.sh.j2
+++ b/templates/aws_s3_restore_artifacts.sh.j2
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -o nounset
+set -o errexit
+
+export PATH=$PATH:/usr/sbin:/sbin:/usr/bin:/bin:/usr/local/bin/
+
+function info { echo -e "$( date +%T )" "\033[1;33m  $1\033[0m"; }
+function ok { echo -e "$( date +%T )" "\033[1;32m  $1\033[0m"; }
+function error { echo -e "$( date +%T )" "\033[1;31m  Error: $1\033[0m"; }
+function die { error "$1"; exit 1; }
+
+function main {
+	GO_USER="{{ gocd_server.user }}"
+	BACKUP_BUCKET="{{ gocd_server.aws.backup_bucket }}"
+	GO_DB_PATH="/home/${GO_USER}/work/go-server/db"
+	ARTIFACTS_DIR="/home/${GO_USER}/work/go-server/artifacts/pipelines"
+	: "${AWS_DEFAULT_REGION:=eu-west-1}"
+
+	export AWS_DEFAULT_REGION
+
+	info "Checking backups exist"
+
+	BACKUP_CHECK="$( aws s3 ls "${BACKUP_BUCKET}"/config | wc -l )"
+
+	if [[ ${BACKUP_CHECK} -eq 0 ]]; then
+		info "No backups found, skipping"
+		exit 0
+	fi
+
+	info "Stopping Go Server"
+	service go-server stop
+
+	info "Synchronising artifacts"
+	mkdir -p "${ARTIFACTS_DIR}"
+	aws s3 sync \
+		"${BACKUP_BUCKET}"/pipelines \
+		"${ARTIFACTS_DIR}" \
+		 || die "Failed to synchronise artifacts"
+	ok "Pipelines artifacts synchronised"
+
+	info "Starting Go Server"
+	service go-server start
+}
+
+main "$@"


### PR DESCRIPTION
With this change the `aws_s3_restore.sh.j2` template renders the `aws_s3_restore.sh` script depending on the `restore_artifacts_on_boot` flag. The changes implemented with GST-2277 require that the `aws_s3_restore.sh` script, which is automatically triggered during instance bootstrap, does not run the artifacts restore from S3 since those files will already be present (due to GoCD server using the persistent_volume Ansible role).

In addition I have added the `aws_s3_restore_artifacts.sh.j2` template. The resulting script can be used to only restore the artifacts from the S3 `mgt-gocd-server-backups` bucket.

The `aws_s3_restore_artifacts.sh` script is useful in a disaster recovery scenario, when the **volumes-mgt-gocd-server** stack was deleted. When recovering from this, the **services-mgt-gocd-server** stack needs to be re-created, which also creates the **volumes-mgt-gocd-server** stack. However the new volume that is mounted at `/home/go/work/go-server/artifacts/` will be empty. In such instance, the `aws_s3_restore_artifacts.sh` script can be triggered manually.