### PR TITLE
[GST-2370] Ensure that the GoCD server role creates a system service account and group

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,9 +19,14 @@ dependencies:
   - role: sansible.users_and_groups
     version: v1.2
     users_and_groups:
+      groups:
+        - name: "{{ gocd_server.group }}"
+          system: yes
       users:
         - name: "{{ gocd_server.user }}"
           gecos: Go CD user
+          group: "{{ gocd_server.group }}"
+          system: yes
     tags:
       - build
 


### PR DESCRIPTION
When GoCD is used with persistent volumes, the uid and gid need to be consistent between instances of the service.
As it stands, the gocd service account is created as a regular user account, so when other new users are added, the uid and gid allocated to gocd can change unexpectedly.
This change ensures the uid and gid are allocated from the system pool, yielding a more stable id allocation.

