### PR TITLE
[GITHUB-37] Python3 Compatibility

### DIFF
--- a/templates/passwd.j2
+++ b/templates/passwd.j2
@@ -1,6 +1,6 @@
 ##
 # {{ ansible_managed }}
 
-{% for name, passwd in gocd_server.passwd_users.iteritems() %}
+{% for name, passwd in gocd_server.passwd_users.items() %}
 {{ name }}:{{ passwd }}
 {% endfor %}


### PR DESCRIPTION
From https://wiki.python.org/moin/Python3.0 :

> Remove dict.iteritems(), dict.iterkeys(), and dict.itervalues().
     Instead: use dict.items(), dict.keys(), and dict.values() respectively. 