### PR TITLE
[GITHUB-41] Updates key URL to work with proxies

### DIFF
--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -25,7 +25,7 @@
 - name: Add GoCD Apt key
   become: yes
   apt_key:
-    keyserver: keyserver.ubuntu.com
+    keyserver: hkp://keyserver.ubuntu.com:80
     id: "{{ gocd_server.repo.key_id }}"
     state: present
 


### PR DESCRIPTION
Adds hkp schema which seems to make gpg install work behind a
corporate proxy.