### PR TITLE
[GITHUB-50] Fixes APT repo for Bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 
 group: stable
-dist: trusty
+dist: xenial
 sudo: required
 
 language: python

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,7 @@ sansible_gocd_server_aws_secret_access_key: ~
 sansible_gocd_server_backup_passwd: backup
 sansible_gocd_server_backup_user: backup
 sansible_gocd_server_dependencies_skip_java: no
+sansible_gocd_server_fix_hostname: yes
 sansible_gocd_server_group: go
 sansible_gocd_server_java_version: 8
 sansible_gocd_server_max_mem: 512m
@@ -39,6 +40,7 @@ sansible_gocd_server_port: 8153
 sansible_gocd_server_port_ssl: 8154
 sansible_gocd_server_repo_key_id: 8816C449
 sansible_gocd_server_repo_source: deb https://download.gocd.org /
+sansible_gocd_server_repo_keyserver: keyserver.ubuntu.com
 sansible_gocd_server_restore_artifacts_on_boot: yes
 sansible_gocd_server_start_opts: ''
 sansible_gocd_server_user: go

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,8 @@ galaxy_info:
   author: sansible
   description: Install the Go Continuous Delivery server.
   license: MIT
-  min_ansible_version: 2.2
+  min_ansible_version: 2.5
+  min_ansible_container_version: 2.5
   platforms:
     - name: Ubuntu
       versions:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,8 +13,13 @@ platforms:
 
 provisioner:
   name: ansible
+  config_options:
+    defaults:
+      # Fix for issue https://github.com/ansible/ansible/issues/43884
+      gather_timeout: 30
   lint:
     name: ansible-lint
+
 
 lint:
   name: yamllint
@@ -30,7 +35,6 @@ lint:
 dependency:
   name: galaxy
   options:
-    ignore-certs: True
     role-file: requirements.yml
 
 scenario:

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,7 @@
 ---
 
 - src: sansible.java
-  version: v2.0
+  version: v2.1.2
 
 - src: sansible.users_and_groups
-  version: v2.0
+  version: v2.0.4

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -6,36 +6,41 @@
     dest: /etc/hosts
     line: "127.0.0.1 localhost {{ ansible_hostname }}"
     regexp: ^127\.0\.0\.1
-  when: ansible_virtualization_type != 'docker'
+  when:
+    - ansible_virtualization_type != 'docker'
+    - sansible_gocd_server_fix_hostname | bool
 
 - name: Install some dependencies
   become: yes
   apt:
-    name: "{{ item }}"
-    update_cache: yes
-  with_items: "{{ sansible_gocd_server_packages }}"
+    name: "{{ sansible_gocd_server_packages }}"
 
 - name: Install AWS CLI
   become: yes
   pip:
-    name: "{{ item }}"
+    name:
+      - awscli
+      - boto
   when: sansible_gocd_server_aws_install_cli
-  with_items:
-    - awscli
-    - boto
 
-- name: Add GoCD Apt key
+- name: Download GoCD PGP key (works with Bionic behind a proxy)
+  become: yes
+  get_url:
+    dest: /usr/local/src/gocd.asc
+    mode: 0644
+    url: "https://{{ sansible_gocd_server_repo_keyserver }}/pks/lookup?op=get&search=0x{{ sansible_gocd_server_repo_key_id }}"
+
+- name: Ensures GoCD PGP key is known
   become: yes
   apt_key:
-    keyserver: hkp://keyserver.ubuntu.com:80
+    file: /usr/local/src/gocd.asc
     id: "{{ sansible_gocd_server_repo_key_id }}"
     state: present
 
-- name: Install GoCD repo
+- name: Add GoCD APT repository
   become: yes
   apt_repository:
     repo: "{{ sansible_gocd_server_repo_source }}"
-    state: present
     update_cache: yes
 
 - name: Install go-server
@@ -59,11 +64,19 @@
     - work/go-server/plugins/external
     - work/go-server/artifacts/pipelines
 
-- name: Add go-server to autostart
+- name: Add go-server to autostart for SysV
   become: yes
   service:
     name: go-server
     enabled: yes
+  when: ansible_service_mgr != "systemd"
+
+- name: Add go-server to autostart for SystemD
+  become: yes
+  systemd:
+    enabled: yes
+    name: go-server
+  when: ansible_service_mgr == "systemd"
 
 - name: Install go-server plugins
   become: yes

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -6,7 +6,9 @@
     dest: /etc/hosts
     line: "127.0.0.1 localhost {{ ansible_hostname }}"
     regexp: ^127\.0\.0\.1
-  when: ansible_virtualization_type != 'docker'
+  when:
+    - ansible_virtualization_type != 'docker'
+    - sansible_gocd_server_fix_hostname | bool
 
 - name: Copy secrets from S3
   become: yes


### PR DESCRIPTION
Ensures that repo tasks work with Bionic behind a Proxy, also
fixes some deprecation notices, updates Travis to Xenial and
ensures that Galaxy requirements use Semver.