### PR TITLE
[GITHUB-52] Fixes restore scripts for SystemD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ sudo: required
 language: python
 python:
   - 2.7
+cache: pip
 
 branches:
   only:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018
+Copyright (c) 2019
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,6 @@
 ANSIBLE_INSTALL_VERSION ?= 2.7.7
-SCENARIO ?= all
-
 PATH := $(PWD)/.venv_ansible$(ANSIBLE_INSTALL_VERSION)/bin:$(shell printenv PATH)
 SHELL := env PATH=$(PATH) /bin/bash
-
 
 ifeq ($(SCENARIO), all)
 SCENARIO_OPT = "--all"
@@ -15,19 +12,16 @@ endif
 .PHONY: all clean destroy help test
 
 
-_check_venv:
-	@if [ ! -e .venv_ansible$(ANSIBLE_INSTALL_VERSION)/bin/activate ]; then \
-	 	echo -e "\033[0;31mERROR: No virtualenv found - run 'make deps' first\033[0m"; \
-		false; \
-	fi
-
 
 ## Make deps, test
 all: deps test
 
+## Setup dependencies
+deps: .venv_ansible$(ANSIBLE_INSTALL_VERSION)
+
 
 ## Activate the virtualenv
-activate: _check_venv
+activate: .venv_ansible$(ANSIBLE_INSTALL_VERSION)
 	@echo -e "\033[0;32mINFO: Activating venv_ansible$(ANSIBLE_INSTALL_VERSION) (ctrl-d to exit)\033[0m"
 	@exec $(SHELL) --init-file .venv_ansible$(ANSIBLE_INSTALL_VERSION)/bin/activate
 
@@ -51,18 +45,24 @@ destroy:
 		echo -e "\033[0;33mWARNING: molecule not found - either remove potential containers manually or run 'make deps' first\033[0m"; \
 	fi
 
+
 ## Login to docker container named '%'
-login_%: _check_venv
+login_%: .venv_ansible$(ANSIBLE_INSTALL_VERSION)
 	@echo -e "\033[0;32mINFO: Logging into $(subst login_,,$@) (ctrl-d to exit)\033[0m"
 	@.venv_ansible$(ANSIBLE_INSTALL_VERSION)/bin/molecule login --host $(subst login_,,$@)
 
+
 ## Run 'molecule test --destroy=never' (run 'make destroy' to destroy containers)
-test: _check_venv
+test: .venv_ansible$(ANSIBLE_INSTALL_VERSION)
 	@.venv_ansible$(ANSIBLE_INSTALL_VERSION)/bin/molecule test $(SCENARIO_OPT) --destroy=never
 
 
+# shortcut for creating venv
+.venv: .venv_ansible$(ANSIBLE_INSTALL_VERSION)
+
+
 ## Create virtualenv, install dependencies
-deps:
+.venv_ansible$(ANSIBLE_INSTALL_VERSION):
 	@if (python -V 2>&1 | grep -qv "Python 2.7"); then \
 		echo -e "\033[0;31mERROR: Only Python 2.7 is supported at this stage\033[0m"; \
 		false; \
@@ -75,13 +75,14 @@ deps:
 
 
 ## Run 'make test' on any file change
-watch: _check_venv
+watch: .venv_ansible$(ANSIBLE_INSTALL_VERSION)
 	@while sleep 1; do \
 		find defaults/ files/ handlers/ meta/ molecule/*/*.yml molecule/*/test/*.py tasks/ templates/ vars/ 2> /dev/null \
 		| entr -d make test; \
 	done
 
 
+## Print this help
 help:
 	@awk -v skip=1 \
 		'/^##/ { sub(/^[#[:blank:]]*/, "", $$0); doc_h=$$0; doc=""; skip=0; next } \

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -1,15 +1,5 @@
 ---
 
-- name: Ensure hostname is resolvable
-  become: yes
-  lineinfile:
-    dest: /etc/hosts
-    line: "127.0.0.1 localhost {{ ansible_hostname }}"
-    regexp: ^127\.0\.0\.1
-  when:
-    - ansible_virtualization_type != 'docker'
-    - sansible_gocd_server_fix_hostname | bool
-
 - name: Install some dependencies
   become: yes
   apt:
@@ -76,6 +66,14 @@
   systemd:
     enabled: yes
     name: go-server
+  when: ansible_service_mgr == "systemd"
+
+- name: Give GoCD user access to the SystemD service
+  become: yes
+  template:
+    dest: /etc/sudoers.d/gocd
+    mode: 0640
+    src: sudoers.d.gocd.j2
   when: ansible_service_mgr == "systemd"
 
 - name: Install go-server plugins

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,15 +1,5 @@
 ---
 
-- name: Ensure hostname is resolvable
-  become: yes
-  lineinfile:
-    dest: /etc/hosts
-    line: "127.0.0.1 localhost {{ ansible_hostname }}"
-    regexp: ^127\.0\.0\.1
-  when:
-    - ansible_virtualization_type != 'docker'
-    - sansible_gocd_server_fix_hostname | bool
-
 - name: Copy secrets from S3
   become: yes
   become_user: "{{ sansible_gocd_server_user }}"

--- a/templates/aws_s3_restore.sh.j2
+++ b/templates/aws_s3_restore.sh.j2
@@ -29,7 +29,12 @@ function main {
 	fi
 
 	info "Stopping Go Server"
+
+{% if ansible_service_mgr == "systemd" -%}
+	sudo systemctl stop go-server
+{% else -%}
 	service go-server stop
+{% endif %}
 
 	info "Downloading latest.tar.gz"
 	aws s3 cp \
@@ -99,7 +104,13 @@ function main {
 {% endif %}
 
 	info "Starting Go Server"
+
+{% if ansible_service_mgr == "systemd" -%}
+	sudo systemctl start go-server
+{% else -%}
 	service go-server start
+{% endif %}
+
 }
 
 main "$@"

--- a/templates/aws_s3_restore_artifacts.sh.j2
+++ b/templates/aws_s3_restore_artifacts.sh.j2
@@ -28,7 +28,12 @@ function main {
 	fi
 
 	info "Stopping Go Server"
+
+{% if ansible_service_mgr == "systemd" -%}
+	sudo systemctl stop go-server
+{% else -%}
 	service go-server stop
+{% endif %}
 
 	info "Synchronising artifacts"
 	mkdir -p "${ARTIFACTS_DIR}"
@@ -39,7 +44,13 @@ function main {
 	ok "Pipelines artifacts synchronised"
 
 	info "Starting Go Server"
+
+{% if ansible_service_mgr == "systemd" -%}
+	sudo systemctl start go-server
+{% else -%}
 	service go-server start
+{% endif %}
+
 }
 
 main "$@"

--- a/templates/sudoers.d.gocd.j2
+++ b/templates/sudoers.d.gocd.j2
@@ -1,0 +1,4 @@
+%{{ sansible_gocd_server_user }} ALL=NOPASSWD: /bin/systemctl restart go-server
+%{{ sansible_gocd_server_user }} ALL=NOPASSWD: /bin/systemctl start go-server
+%{{ sansible_gocd_server_user }} ALL=NOPASSWD: /bin/systemctl status go-server
+%{{ sansible_gocd_server_user }} ALL=NOPASSWD: /bin/systemctl stop go-server


### PR DESCRIPTION
Makes restore and backup scripts compatible with SystemD, the
GoCD user has to be able to stop/start the go-server service
so the scripts work.

Also updated travis, License and Makefile from the scaffold.